### PR TITLE
Fix typo in codegen script

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -8,6 +8,6 @@ SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ${GOPATH}/src/k8s.io/code-generator)}
 
 vendor/k8s.io/code-generator/generate-groups.sh all \
-  github.com/openshift-evangelist/crd-code-generation/pkg/client github.com/openshift-evangelist/crd-code-generation/pkg/apis \
+  github.com/openshift-evangelists/crd-code-generation/pkg/client github.com/openshift-evangelists/crd-code-generation/pkg/apis \
   example.com:v1 \
   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -17,7 +17,7 @@ package versioned
 
 import (
 	glog "github.com/golang/glog"
-	examplev1 "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1"
+	examplev1 "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -16,9 +16,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned"
-	examplev1 "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1"
-	fakeexamplev1 "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1/fake"
+	clientset "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned"
+	examplev1 "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1"
+	fakeexamplev1 "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	examplev1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
+	examplev1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package scheme
 
 import (
-	examplev1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
+	examplev1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/example/v1/database.go
+++ b/pkg/client/clientset/versioned/typed/example/v1/database.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
-	scheme "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned/scheme"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
+	scheme "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned/scheme"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/example/v1/example_client.go
+++ b/pkg/client/clientset/versioned/typed/example/v1/example_client.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
-	"github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned/scheme"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
+	"github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/clientset/versioned/typed/example/v1/fake/fake_database.go
+++ b/pkg/client/clientset/versioned/typed/example/v1/fake/fake_database.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	example_com_v1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
+	example_com_v1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/example/v1/fake/fake_example_client.go
+++ b/pkg/client/clientset/versioned/typed/example/v1/fake/fake_example_client.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned/typed/example/v1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/informers/externalversions/example/interface.go
+++ b/pkg/client/informers/externalversions/example/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package example
 
 import (
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/client/informers/externalversions/example/v1"
-	internalinterfaces "github.com/openshift-evangelist/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/client/informers/externalversions/example/v1"
+	internalinterfaces "github.com/openshift-evangelists/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/example/v1/database.go
+++ b/pkg/client/informers/externalversions/example/v1/database.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1
 
 import (
-	example_com_v1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
-	versioned "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/openshift-evangelist/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/client/listers/example/v1"
+	example_com_v1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
+	versioned "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/openshift-evangelists/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/client/listers/example/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/example/v1/interface.go
+++ b/pkg/client/informers/externalversions/example/v1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/openshift-evangelist/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/openshift-evangelists/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -19,9 +19,9 @@ limitations under the License.
 package externalversions
 
 import (
-	versioned "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned"
-	example "github.com/openshift-evangelist/crd-code-generation/pkg/client/informers/externalversions/example"
-	internalinterfaces "github.com/openshift-evangelist/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
+	versioned "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned"
+	example "github.com/openshift-evangelists/crd-code-generation/pkg/client/informers/externalversions/example"
+	internalinterfaces "github.com/openshift-evangelists/crd-code-generation/pkg/client/informers/externalversions/internalinterfaces"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -20,7 +20,7 @@ package externalversions
 
 import (
 	"fmt"
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalinterfaces
 
 import (
-	versioned "github.com/openshift-evangelist/crd-code-generation/pkg/client/clientset/versioned"
+	versioned "github.com/openshift-evangelists/crd-code-generation/pkg/client/clientset/versioned"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	time "time"

--- a/pkg/client/listers/example/v1/database.go
+++ b/pkg/client/listers/example/v1/database.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	v1 "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1"
+	v1 "github.com/openshift-evangelists/crd-code-generation/pkg/apis/example.com/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"


### PR DESCRIPTION
Fixes #1 

There was a typo in the `update-codegen` script due to which it panicked:

```
Generating deepcopy funcs
ERROR: logging before flag.Parse: F1025 11:30:35.489967   31019 main.go:79] Error: Failed making a parser: unable to add directory "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1": unable to import "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1": cannot find package "github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1" in any of:
	/home/nikhita/gocode/src/github.com/openshift-evangelists/crd-code-generation/vendor/github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1 (vendor tree)
	/usr/local/go/src/github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1 (from $GOROOT)
	/home/nikhita/gocode/src/github.com/openshift-evangelist/crd-code-generation/pkg/apis/example.com/v1 (from $GOPATH)
goroutine 1 [running]:
github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog.stacks(0xc42000e000, 0xc4200f4000, 0x310, 0x365)
	/home/nikhita/gocode/src/github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog/glog.go:769 +0xcf
github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog.(*loggingT).output(0x85d7a0, 0xc400000003, 0xc4200f0000, 0x838c40, 0x7, 0x4f, 0x0)
	/home/nikhita/gocode/src/github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog/glog.go:720 +0x345
github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog.(*loggingT).printf(0x85d7a0, 0x3, 0x6e25be, 0x9, 0xc4200e7f30, 0x1, 0x1)
	/home/nikhita/gocode/src/github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog/glog.go:655 +0x14c
github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog.Fatalf(0x6e25be, 0x9, 0xc4200e7f30, 0x1, 0x1)
	/home/nikhita/gocode/src/github.com/openshift-evangelists/crd-code-generation/vendor/github.com/golang/glog/glog.go:1148 +0x67
main.main()
	/home/nikhita/gocode/src/github.com/openshift-evangelists/crd-code-generation/vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go:79 +0x226
```

/cc @sttts 