### PR TITLE
use the CODEGEN_PKG variable

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -7,7 +7,7 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ${GOPATH}/src/k8s.io/code-generator)}
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+${CODEGEN_PKG}/generate-groups.sh all \
   github.com/openshift-evangelists/crd-code-generation/pkg/client github.com/openshift-evangelists/crd-code-generation/pkg/apis \
   example.com:v1 \
   --go-header-file ${SCRIPT_ROOT}/hack/custom-boilerplate.go.txt


### PR DESCRIPTION
I read the https://blog.openshift.com/kubernetes-deep-dive-code-generation-customresources/ blog post and noticed that the script only works using vendoring. The CODEGEN_PKG variable is set but not used to call the generator script.